### PR TITLE
Remove verification against imported tuple files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,10 +108,7 @@ tasks.register("generateTuples") {
     
     val outputDir = layout.projectDirectory.dir("src/generated/kotlin/io/github/mirrgieriana/xarpite/xarpeg").asFile
     val outputDirParsers = layout.projectDirectory.dir("src/generated/kotlin/io/github/mirrgieriana/xarpite/xarpeg/parsers").asFile
-    
-    val tuplesKt = file("imported/src/commonMain/kotlin/io/github/mirrgieriana/xarpite/xarpeg/Tuples.kt")
-    val tupleParserKt = file("imported/src/commonMain/kotlin/io/github/mirrgieriana/xarpite/xarpeg/parsers/TupleParser.kt")
-    
+
     val generatedTuplesKt = outputDir.resolve("Tuples.kt")
     val generatedTupleParserKt = outputDirParsers.resolve("TupleParser.kt")
     
@@ -260,21 +257,7 @@ tasks.register("generateTuples") {
         }
         generatedTupleParserKt.writeText(tupleParserContent)
         println("Generated: ${generatedTupleParserKt.absolutePath}")
-        
-        // Verify Tuples.kt
-        val expectedTuplesContent = tuplesKt.readText()
-        if (tuplesContent != expectedTuplesContent) {
-            throw GradleException("Generated Tuples.kt does not match imported/src/commonMain/kotlin/io/github/mirrgieriana/xarpite/xarpeg/Tuples.kt")
-        }
-        println("Verified: Tuples.kt matches imported file")
-        
-        // Verify TupleParser.kt
-        val expectedTupleParserContent = tupleParserKt.readText()
-        if (tupleParserContent != expectedTupleParserContent) {
-            throw GradleException("Generated TupleParser.kt does not match imported/src/commonMain/kotlin/io/github/mirrgieriana/xarpite/xarpeg/parsers/TupleParser.kt")
-        }
-        println("Verified: TupleParser.kt matches imported file")
-        
+
         println("All tuple files generated and verified successfully!")
     }
 }


### PR DESCRIPTION
Eliminated code that compared generated Tuples.kt and TupleParser.kt with their imported counterparts. This simplifies the generateTuples task by focusing only on file generation.